### PR TITLE
Add upgrade card text to fancy print view

### DIFF
--- a/coffeescripts/xwing.coffee
+++ b/coffeescripts/xwing.coffee
@@ -2370,6 +2370,7 @@ class GenericAddon
                         </div>
                     </div>
                     <div class="upgrade-name"><i class="xwing-miniatures-font xwing-miniatures-font-#{upgrade_slot_font}"></i> #{@data.name}</div>
+                    <div class="upgrade-text">#{@data.text}</div>
                 </div>
             """
         else

--- a/coffeescripts/xwing.coffee
+++ b/coffeescripts/xwing.coffee
@@ -2371,6 +2371,7 @@ class GenericAddon
                     </div>
                     <div class="upgrade-name"><i class="xwing-miniatures-font xwing-miniatures-font-#{upgrade_slot_font}"></i> #{@data.name}</div>
                     <div class="upgrade-text">#{@data.text}</div>
+                    <div style="clear: both;"></div>
                 </div>
             """
         else

--- a/sass/xwing-print.sass
+++ b/sass/xwing-print.sass
@@ -203,7 +203,6 @@ body
         .upgrade-name
           position: relative
           float: right
-          top: 5px
           text-align: right
           line-height: $upgrade-circle-diameter
           margin-right: $upgrade-circle-diameter - 10px

--- a/sass/xwing-print.sass
+++ b/sass/xwing-print.sass
@@ -166,8 +166,10 @@ body
 
       .upgrade-container
         position: relative
-        margin-bottom: -15px
-        margin-right: -2.5px
+        margin-bottom: 5px
+        margin-left: 0.75in
+        margin-right: 0.365in
+        border: 1px dotted lightgray
         clear: both
 
         .mask
@@ -205,6 +207,9 @@ body
           text-align: right
           line-height: $upgrade-circle-diameter
           margin-right: $upgrade-circle-diameter - 10px
+
+        .upgrade-text
+          padding: 5px
 
   .printable-footer
     position: fixed

--- a/sass/xwing-screen.sass
+++ b/sass/xwing-screen.sass
@@ -142,9 +142,12 @@ $upgrade-circle-border-width: 5px
 
     .upgrade-container
       position: relative
-      margin-bottom: -15px
-      margin-right: -2.5px
+      padding-bottom: 3px
+      margin-left: 60px
+      margin-bottom: 5px
+      margin-right: 30px
       clear: both
+      border: 1px dotted lightgray
 
       .mask
         position: relative
@@ -153,6 +156,7 @@ $upgrade-circle-border-width: 5px
         width: $upgrade-circle-diameter
         height: $upgrade-circle-diameter
         z-index: 999
+        margin-right: 5px
 
       .outer-circle
         width: $upgrade-circle-diameter
@@ -175,12 +179,13 @@ $upgrade-circle-border-width: 5px
           color: white
 
       .upgrade-name
-        position: relative
         float: right
-        top: 5px
         text-align: right
         line-height: $upgrade-circle-diameter
         margin-right: $upgrade-circle-diameter - 10px
+
+      .upgrade-text
+        padding: 5px
 
 .bbcode-list textarea, textarea.xws-content
   width: 95%


### PR DESCRIPTION
Examples:

Fancy web view:
![screenshot 2015-01-22 17 32 20](https://cloud.githubusercontent.com/assets/519506/5866304/fb22264e-a25d-11e4-8804-dd6f7751cab3.png)

Fancy print view (from PDF):
![screenshot 2015-01-22 17 35 40](https://cloud.githubusercontent.com/assets/519506/5866305/fe0d2f2a-a25d-11e4-8f7e-7fdd2d60939f.png)

