### PR TITLE
Secondary weapon range and damage in fancy print view

### DIFF
--- a/coffeescripts/xwing.coffee
+++ b/coffeescripts/xwing.coffee
@@ -2374,14 +2374,26 @@ class GenericAddon
     toHTML: ->
         if @data?
             upgrade_slot_font = (@data.slot ? @type).toLowerCase().replace(/[^0-9a-z]/gi, '')
+
+            attackHTML = if (@data.attack?) then $.trim """
+                <div class="upgrade-attack">
+                    <span class="upgrade-attack-range">#{@data.range}</span>
+                    <span class="info-data info-attack">#{@data.attack}</span>
+                    <i class="xwing-miniatures-font xwing-miniatures-font-attack"></i>
+                </div>
+            """ else ''
+
             $.trim """
                 <div class="upgrade-container">
-                    <div class="mask">
-                        <div class="outer-circle">
-                            <div class="inner-circle upgrade-points">#{@data.points}</div>
+                    <div class="upgrade-stats">
+                        <div class="upgrade-name"><i class="xwing-miniatures-font xwing-miniatures-font-#{upgrade_slot_font}"></i> #{@data.name}</div>
+                        <div class="mask">
+                            <div class="outer-circle">
+                                <div class="inner-circle upgrade-points">#{@data.points}</div>
+                            </div>
                         </div>
+                        #{attackHTML}
                     </div>
-                    <div class="upgrade-name"><i class="xwing-miniatures-font xwing-miniatures-font-#{upgrade_slot_font}"></i> #{@data.name}</div>
                     <div class="upgrade-text">#{@data.text}</div>
                     <div style="clear: both;"></div>
                 </div>

--- a/sass/xwing-print.sass
+++ b/sass/xwing-print.sass
@@ -26,8 +26,7 @@ body
 
   .info-data
     color: black
-    position: relative
-    top: -5px
+    vertical-align: middle
 
   .fancy-header
     border: $fancy-header-height solid black
@@ -148,7 +147,7 @@ body
         margin-top: -$fancy-pilot-header-height + 0.1
         
         .xwing-miniatures-font
-          vertical-align: 0.3em
+          vertical-align: middle
           color: black
 
     .fancy-pilot-text
@@ -166,25 +165,28 @@ body
 
       .upgrade-container
         position: relative
-        margin-bottom: 5px
+        margin-bottom: 0.04in
         margin-left: 0.75in
         margin-right: 0.365in
         border: 1px dotted lightgray
         clear: both
 
-        .mask
-          position: relative
+        .upgrade-stats
           float: right
-          clear: both
+          text-align: right
+
+        .mask
+          display: inline-block
+          vertical-align: middle
           width: $upgrade-circle-diameter
           height: $upgrade-circle-diameter
           z-index: 999
+          margin-right: 0.04in
 
         .outer-circle
           width: $upgrade-circle-diameter
           height: $upgrade-circle-diameter
           border-radius: $upgrade-circle-diameter / 2
-          margin-left: -$upgrade-circle-diameter / 2
           background-color: white
 
           .inner-circle
@@ -201,11 +203,30 @@ body
             color: white
 
         .upgrade-name
-          position: relative
-          float: right
-          text-align: right
+          display: inline-block
+          vertical-align: middle
           line-height: $upgrade-circle-diameter
-          margin-right: $upgrade-circle-diameter - 10px
+
+        .upgrade-attack
+          text-align: right
+          margin-right: 0.07in
+          margin-top: 0.02in
+
+          .upgrade-attack-range
+            vertical-align: middle
+            padding: 2px 8px
+            color: white
+            background-color: black
+            font-family: kimberley
+            font-size: 1.2em
+
+          .xwing-miniatures-font-attack
+            background: black
+            color: white
+            vertical-align: middle
+
+          .info-attack
+            margin-right: 0.02in
 
         .upgrade-text
           padding: 5px

--- a/sass/xwing-screen.sass
+++ b/sass/xwing-screen.sass
@@ -126,7 +126,7 @@ $upgrade-circle-border-width: 5px
       margin-top: -$fancy-pilot-header-height + 5
       
       .xwing-miniatures-font
-        vertical-align: 0.3em
+        vertical-align: middle
 
   .fancy-pilot-text
     margin-left: $fancy-pilot-header-height * 2
@@ -149,10 +149,15 @@ $upgrade-circle-border-width: 5px
       clear: both
       border: 1px dotted lightgray
 
-      .mask
-        position: relative
+      .upgrade-stats
         float: right
-        clear: both
+        text-align: right
+        margin-left: 10px
+        min-width: 150px
+
+      .mask
+        display: inline-block
+        vertical-align: middle
         width: $upgrade-circle-diameter
         height: $upgrade-circle-diameter
         z-index: 999
@@ -162,7 +167,6 @@ $upgrade-circle-border-width: 5px
         width: $upgrade-circle-diameter
         height: $upgrade-circle-diameter
         border-radius: $upgrade-circle-diameter / 2
-        margin-left: -$upgrade-circle-diameter / 2
         background-color: white
 
         .inner-circle
@@ -179,10 +183,28 @@ $upgrade-circle-border-width: 5px
           color: white
 
       .upgrade-name
-        float: right
-        text-align: right
+        display: inline-block
+        vertical-align: middle
         line-height: $upgrade-circle-diameter
-        margin-right: $upgrade-circle-diameter - 10px
+
+      .upgrade-attack
+        text-align: right
+        margin-top: 4px
+        margin-right: 8px
+
+        .upgrade-attack-range
+          vertical-align: middle
+          padding: 2px 8px
+          color: white
+          background-color: black
+          font-family: kimberley
+          font-size: 1.2em
+
+        .info-attack
+          margin-right: 2px
+
+        .xwing-miniatures-font
+          vertical-align: middle
 
       .upgrade-text
         padding: 5px

--- a/sass/xwing.sass
+++ b/sass/xwing.sass
@@ -188,6 +188,7 @@ ul.squad-list
 .icon
   background-image: url($xwing_icons_png)
   background-repeat: no-repeat
+  vertical-align: middle
 
 img.icon-straight
   @extend .icon
@@ -398,8 +399,7 @@ select.card-selector
   width: 100%
 
 .fancy-list .info-data
-  position: relative
-  top: -5px
+  vertical-align: middle
 
 .simple-list
   font-family: Arial,Helvetica,sans-serif

--- a/tests/test_view_as_text.coffee
+++ b/tests/test_view_as_text.coffee
@@ -12,8 +12,8 @@ casper.test.begin "View as text", (test) ->
             pilot: 'Wedge Antilles'
             upgrades: [
                 null
+                'Proton Torpedoes'
                 null
-                'R2 Astromech'
                 null
             ]
         }
@@ -38,8 +38,12 @@ casper.test.begin "View as text", (test) ->
     .then ->
         test.assertSelectorHasText('#rebel-builder .modal .fancy-list', "When attacking, reduce the defender's agility")
         test.assertSelectorHasText('#rebel-builder .modal .fancy-list', "You may perform actions even while you have")
-        test.assertSelectorHasText('#rebel-builder .modal .fancy-list', "R2 Astromech")
+        test.assertSelectorHasText('#rebel-builder .modal .fancy-list', "Proton Torpedoes")
+        test.assertSelectorHasText('#rebel-builder .modal .fancy-list', "Attack (target lock):")
+        test.assertSelectorHasText('#rebel-builder .modal .fancy-list', "2-3")
+        test.assertSelectorHasText('#rebel-builder .modal .fancy-list', "4")
         test.assertSelectorHasText('#rebel-builder .modal .fancy-list', "Push the Limit")
+        test.assertSelectorHasText('#rebel-builder .modal .fancy-list', "Once per round, after you perform an action")
     .then ->
         @click('#rebel-builder .modal .select-simple-view')
         @waitUntilVisible('#rebel-builder .modal .simple-list')
@@ -55,10 +59,10 @@ casper.test.begin "View as text", (test) ->
         bbcode = @evaluate ->
             $('#rebel-builder .modal .bbcode-list textarea').val()
         test.assertNot(bbcode.indexOf('[b]Wedge Antilles (29)[/b]') == -1)
-        test.assertNot(bbcode.indexOf('[i]R2 Astromech (1)[/i]') == -1)
+        test.assertNot(bbcode.indexOf('[i]Proton Torpedoes (4)[/i]') == -1)
         test.assertNot(bbcode.indexOf('[b]Tycho Celchu (26)[/b]') == -1)
         test.assertNot(bbcode.indexOf('[i]Push the Limit (3)[/i]') == -1)
-        test.assertNot(bbcode.indexOf('[b][i]Total: 59[/i][/b]') == -1)
+        test.assertNot(bbcode.indexOf('[b][i]Total: 62[/i][/b]') == -1)
 
     .run ->
         test.done()


### PR DESCRIPTION
Add secondary weapon range and damage in the fancy print view.  Re-works the alignment of the stat bar icons as well to use vertical-align: middle instead of fixed offsets.

Also includes unit tests for upgrade test and secondary weapon range and damage in the fancy print view.

Resolves #154.