### PR TITLE
#240: Copy to clipboard

### DIFF
--- a/coffeescripts/cards-en.coffee
+++ b/coffeescripts/cards-en.coffee
@@ -102,7 +102,8 @@ exportObj.translations.English =
         '.randomize' : 'Random!'
         '.randomize-options' : 'Randomizer options…'
         # Print/View modal
-        '.bbcode-list' : 'Copy the BBCode below and paste it into your forum post.<textarea></textarea>'
+        '.bbcode-list' : 'Copy the BBCode below and paste it into your forum post.<textarea></textarea><button class="btn btn-copy">Copy</button>'
+        '.html-list' : '<textarea></textarea><button class="btn btn-copy">Copy</button>'
         '.vertical-space-checkbox' : """Add space for damage/upgrade cards when printing <input type="checkbox" class="toggle-vertical-space" />"""
         '.color-print-checkbox' : """Print color <input type="checkbox" class="toggle-color-print" />"""
         '.print-list' : '<i class="icon-print"></i>&nbsp;Print'

--- a/coffeescripts/cards-es.coffee
+++ b/coffeescripts/cards-es.coffee
@@ -121,7 +121,8 @@ exportObj.translations['Español'] =
         '.randomize' : 'Aleatorio!'
         '.randomize-options' : 'Opciones de aleatoriedad…'
         # Print/View modal
-        '.bbcode-list' : 'Copia el BBCode de debajo y pegalo en el post de tu foro.<textarea></textarea>'
+        '.bbcode-list' : 'Copia el BBCode de debajo y pegalo en el post de tu foro.<textarea></textarea><button class="btn btn-copy">Copia</button>'
+        '.html-list' : '<textarea></textarea><button class="btn btn-copy">Copia</button>'
         '.vertical-space-checkbox' : """Añade espacio para cartas de daño/mejora cuando imprima. <input type="checkbox" class="toggle-vertical-space" />"""
         '.color-print-checkbox' : """Imprima en color. <input type="checkbox" class="toggle-color-print" />"""
         '.print-list' : '<i class="icon-print"></i>&nbsp;Imprimir'

--- a/coffeescripts/cards-fr.coffee
+++ b/coffeescripts/cards-fr.coffee
@@ -98,7 +98,8 @@ exportObj.translations['Français'] =
         '.randomize' : 'Aléatoire'
         '.randomize-options' : 'Options…'
         # Print/View modal
-        '.bbcode-list' : 'Copiez le BBCode ci-dessous et collez-le dans votre post.<textarea></textarea>'
+        '.bbcode-list' : 'Copiez le BBCode ci-dessous et collez-le dans votre post.<textarea></textarea><button class="btn btn-copy">Copiez</button>'
+        '.html-list' : '<textarea></textarea><button class="btn btn-copy">Copiez</button>'
         '.vertical-space-checkbox' : """Ajouter de l'espace pour les cartes d'amélioration et de dégâts lors de l'impression <input type="checkbox" class="toggle-vertical-space" />"""
         '.color-print-checkbox' : """Imprimer en couleur <input type="checkbox" class="toggle-color-print" />"""
         '.print-list' : '<i class="icon-print"></i>&nbsp;Imprimer'

--- a/coffeescripts/cards-pl.coffee
+++ b/coffeescripts/cards-pl.coffee
@@ -98,7 +98,8 @@ exportObj.translations['Polski'] =
         '.randomize' : 'randomizuj'
         '.randomize-options' : 'Opcje ...'
         # Print/View modal
-        '.bbcode-list' : 'Skopiuj BBCode poniżej i wklej go do swojego posta.<textarea></textarea>'
+        '.bbcode-list' : 'Skopiuj BBCode poniżej i wklej go do swojego posta.<textarea></textarea><button class="btn btn-copy">Skopiuj</button>'
+        '.html-list' : '<textarea></textarea><button class="btn btn-copy">Skopiuj</button>'
         '.vertical-space-checkbox' : """Dodaj miejsce na karty ulepszeń \ uszkodzeń podczas drukowania <input type="checkbox" class="toggle-vertical-space" />"""
         '.color-print-checkbox' : """Wydrukuj w kolorze <input type="checkbox" class="toggle-color-print" />"""
         '.print-list' : '<i class="icon-print"></i>&nbsp;Drukuj'

--- a/coffeescripts/cards-ru.coffee
+++ b/coffeescripts/cards-ru.coffee
@@ -98,7 +98,8 @@ exportObj.translations['Русский'] =
         '.randomize' : 'Случайно'
         '.randomize-options' : 'Опции генератора случайности'
         # Print/View modal
-        '.bbcode-list' : 'Скопируйте BBCode ниже и вставьте в пост на форуме.<textarea></textarea>'
+        '.bbcode-list' : 'Скопируйте BBCode ниже и вставьте в пост на форуме.<textarea></textarea><button class="btn btn-copy">Скопируйте</button>'
+        '.html-list' : '<textarea></textarea><button class="btn btn-copy">Скопируйте</button>'
         '.vertical-space-checkbox' : """Добавить пространство для карт повреждений\улучшений на распечатке. <input type="checkbox" class="toggle-vertical-space" />"""
         '.color-print-checkbox' : """Печать в цвете. <input type="checkbox" class="toggle-color-print" />"""
         '.print-list' : '<i class="icon-print"></i>&nbsp;Печать'

--- a/coffeescripts/xwing.coffee
+++ b/coffeescripts/xwing.coffee
@@ -239,11 +239,11 @@ class exportObj.SquadBuilder
                 <div class="fancy-list hidden-phone"></div>
                 <div class="simple-list"></div>
                 <div class="bbcode-list">
-                    Copy the BBCode below and paste it into your forum post.
-                    <textarea></textarea>
+                    <p>Copy the BBCode below and paste it into your forum post.</p>
+                    <textarea></textarea><button class="btn btn-copy">Copy</button>
                 </div>
                 <div class="html-list">
-                    <textarea></textarea>
+                    <textarea></textarea><button class="btn btn-copy">Copy</button>
                 </div>
             </div>
             <div class="modal-footer hidden-print">
@@ -280,6 +280,16 @@ class exportObj.SquadBuilder
         @html_textarea.attr 'readonly', 'readonly'
         @toggle_vertical_space_container = $ @list_modal.find('.vertical-space-checkbox')
         @toggle_color_print_container = $ @list_modal.find('.color-print-checkbox')
+
+        @list_modal.on 'click', 'button.btn-copy', (event) =>
+            @self = $(event.currentTarget)
+            @self.siblings('textarea').select()
+            @success = document.execCommand('copy')
+            if @success
+                @self.addClass 'btn-success'
+                setTimeout ( =>
+                    @self.removeClass 'btn-success'
+                ), 1000
 
         @select_simple_view_button = $ @list_modal.find('.select-simple-view')
         @select_simple_view_button.click (e) =>
@@ -1092,7 +1102,7 @@ class exportObj.SquadBuilder
     getAvailableModificationsIncluding: (include_modification, ship, term='') ->
         # Returns data formatted for Select2
         available_modifications = (modification for modification_name, modification of exportObj.modificationsByLocalizedName when @matcher(modification_name, term) and (not modification.ship? or modification.ship == ship.data.name))
-        
+
         eligible_modifications = (modification for modification_name, modification of available_modifications when (not modification.unique? or modification not in @uniques_in_use['Modification']) and (not modification.faction? or @isOurFaction(modification.faction)) and (not (ship? and modification.restriction_func?) or modification.restriction_func ship))
 
         # I finally had to add a special case :(  If something else demands it

--- a/coffeescripts/xwing.coffee
+++ b/coffeescripts/xwing.coffee
@@ -281,8 +281,8 @@ class exportObj.SquadBuilder
         @toggle_vertical_space_container = $ @list_modal.find('.vertical-space-checkbox')
         @toggle_color_print_container = $ @list_modal.find('.color-print-checkbox')
 
-        @list_modal.on 'click', 'button.btn-copy', (event) =>
-            @self = $(event.currentTarget)
+        @list_modal.on 'click', 'button.btn-copy', (e) =>
+            @self = $(e.currentTarget)
             @self.siblings('textarea').select()
             @success = document.execCommand('copy')
             if @success


### PR DESCRIPTION
Added a button to the BBCode and HTML list modals, which first when clicked selects the contents of the textarea and then performs an exec('copy') command. If the copy command is not supported on the device, text should remain selected to ease manual copying.

Relates to issue #240 