### PR TITLE
#241: Updating some of the package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "grunt-contrib-jade": "^0.14.1",
     "grunt-contrib-uglify": "^0.8.0",
     "grunt-iced-coffee": "^0.7.0-a",
-    "grunt-sass": "^0.18.1",
+    "grunt-sass": "^1.0.0",
     "iced-coffee-script": "^1.8.0-d",
     "markdown": "^0.5.0",
-    "node-sass": "^3.0.0-alpha.0",
-    "phantomjs": "^1.9.10"
+    "node-sass": "^3.3.3",
+    "phantomjs": "^1.9.18"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
Update dependencies (`grunt-sass` in particular) which are causing a very outdated version of `node-sass` to install and fail the `libsass` binding post-install script.

See #241 