### PR TITLE
Ghost cards and a few extra things

### DIFF
--- a/coffeescripts/cards-es.coffee
+++ b/coffeescripts/cards-es.coffee
@@ -70,6 +70,10 @@ exportObj.translations['Español'] =
         "T-70 X-Wing Expansion Pack": "Pack de Expansión T-70 Ala-X"
         "TIE/fo Fighter Expansion Pack": "Pack de Expansión Caza TIE/fo"
         "Imperial Assault Carrier Expansion Pack": "Pack de Expansión Portacazas de Asalto Imperial"
+        "Ghost Expansion Pack": "Pack de Expansión Espíritu"
+        "Inquisitor's TIE Expansion Pack": "Pack de Expansión TIE del Inquisidor"
+        "Mist Hunter Expansion Pack": "Pack de Expansión Cazador de la Niebla"
+        "Punishing One Expansion Pack": "Pack de Expansión Castigadora"
     ui:
         shipSelectorPlaceholder: "Selecciona una nave"
         pilotSelectorPlaceholder: "Selecciona un piloto"
@@ -332,6 +336,10 @@ exportObj.cardLoaders['Español'] = () ->
             ship: "Bombardero TIE"
         "Gamma Squadron Pilot":
             name: "Piloto del escuadrón Gamma"
+            ship: "Bombardero TIE"
+        "Gamma Squadron Veteran":
+            ship: "Bombardero TIE"
+        '"Dea???"':
             ship: "Bombardero TIE"
         "Captain Jonus":
             name: "Capitán Jonus"
@@ -687,7 +695,7 @@ exportObj.cardLoaders['Español'] = () ->
             ship: "Caza TIE/fo"
             text: '''Las naves enemigas que tienes fijadas como blanco no pueden modificar ningún dado cuando te atacan o se defienden de tus ataques.'''
         'Hera Syndulla':
-            text: '''When you reveal a green or red maneuver, you may rotate your dial to another maneuver of the same difficulty.'''
+            text: '''Cuando reveles una maniobra verde o roja, puedes girar tu selector de maniobras para escoger otra maniobra del mismo color.'''
         '"Youngster"':
             name: "Pipiolo"
             ship: "Caza TIE"
@@ -700,7 +708,7 @@ exportObj.cardLoaders['Español'] = () ->
             ship: "Caza TIE"
             text: """Cuando otra nave aliada que tengas a alcance 1 gaste una ficha de Concentración, asigna 1 ficha de Concentración a tu nave."""
         'Ezra Bridger':
-            text: """When defending, if you are stressed, you may change up to 2 of your %FOCUS% results to %EVADE% results."""
+            text: """Cuando te defiendas, si estás bajo tensión, puedes cambiar hasta 2 de tus resultados %FOCUS% por resultados %EVADE%."""
         '"Zeta Leader"':
             name: "Jefe Zeta"
             text: '''Cuando ataques, si no estás bajo tensión, puedes recibir 1 ficha de Tensión para tirar 1 dado de ataque adicional.'''
@@ -710,15 +718,19 @@ exportObj.cardLoaders['Español'] = () ->
             text: '''Mientras no tengas ninguna carta de Daño asignada, se considera que tienes Habilidad 12.'''
             ship: "Caza TIE/fo"
         "Kanan Jarrus":
-            text: """When an enemy ship at Range 1-2 is attacking, you may spend a focus token.  If you do, the attacker rolls 1 fewer attack die."""
+            text: """Cuando una nave enemiga que tengas a alcance 1-2 efectúe un ataque, puedes gastar una ficha de Concentración. Si decides hacerlo, el atacante tira 1 dado de ataque menos."""
         '"Chopper"':
-            text: """At the start of the Combat phase, each enemy ship you are touching receives 1 stress token."""
+            text: """Al comienzo de la fase de Combate, toda nave enemiga con la que estés en contacto recibe 1 ficha de Tensión."""
         'Hera Syndulla (Attack Shuttle)':
-            text: """When you reveal a green or red maneuver, you may rotate your dial to another maneuver of the same difficulty."""
+            name: "Hera Syndulla (Lanzadera de Ataque)"
+            text: """Cuando reveles una maniobra verde o roja, puedes girar tu selector de maniobras para escoger otra maniobra del mismo color."""
         'Sabine Wren':
-            text: """Immediately before you reveal your maneuver, you may perform a free boost or barrel roll action."""
+            text: """Inmediatamente antes de revelar tu maniobra, puedes realizar una acción gratuita de impulso o tonel volado."""
         '"Zeb" Orrelios':
-            text: '''When defending, you may cancel %CRIT% results before %HIT% results.'''
+            text: '''Cuando te defiendas, puedes anular resultados %CRIT% antes de anular resultados %HIT%.'''
+        "Lothal Rebel":
+            name: "Rebelde de Lothal"
+            ship: "VCX-100"
         'Tomax Bren':
             text: '''Once per round, after you discard an %ELITE% Upgrade card, flip that card faceup.'''
             ship: "Bombardero TIE"
@@ -1186,24 +1198,26 @@ exportObj.cardLoaders['Español'] = () ->
         'Docking Clamps':
             text: '''%GOZANTIONLY% %LIMITED%%LINEBREAK%You may attach 4 up to TIE fighters, TIE interceptors, TIE bombers, or TIE Advanced to this ship.  All attached ships must have the same ship type.'''
         '"Zeb" Orrelios':
-            text: """%REBELONLY%%LINEBREAK%Enemy ships inside your firing arc that you are touching are not considered to be touching you when either you or they activate during the Combat phase."""
+            text: """%REBELONLY%%LINEBREAK%Las naves enemigas dentro de tu arco de fuego que estén en contacto contigo no se consideran en contacto contigo cuando tú o ellas os activéis durante la fase de Combate."""
         'Kanan Jarrus':
-            text: """%REBELONLY%%LINEBREAK%Once per round, after a friendly ship at Range 1-2 executes a white maneuver, you may remove 1 stress token from that ship."""
+            text: """%REBELONLY%%LINEBREAK%Una vez por ronda, después de que una nave aliada que tengas a alcance 1-2 ejecute una maniobra blanca, puedes quitar 1 ficha de Tensión de esa nave."""
         'Reinforced Deflectors':
-            text: """%LARGESHIPONLY%%LINEBREAK%After you suffer 3 or more damage from an attack, recover one shield (up to your shield value)."""
+            name: "Deflectores Reforzados"
+            text: """%LARGESHIPONLY%%LINEBREAK%Después de que sufras 3 o más de daño debido a un mismo ataque, recuperas 1 ficha de Escudos (hasta un máximo igual a tu valor de Escudos)."""
         'Dorsal Turret':
-            text: """<strong>Attack:</strong> Attack 1 ship (even a ship outside your firing arc).%LINEBREAK%If the target of this attack is at Range 1, roll 1 additional attack die."""
+            name: "Torreta Dorsal"
+            text: """<strong>Ataque:</strong> Ataca a 1 nave (aunque esté fuera de tu arco de fuego).%LINEBREAK%Si el objetivo de este ataque está a alcance 1, tiras 1 dado de ataque adicional."""
         'Targeting Astromech':
             name: "Droide Astromecánico de Selección de Blancos"
             text: '''Después de que ejecutes una maniobra roja, puedes fijar un blanco.'''
         'Hera Syndulla':
-            text: """%REBELONLY%%LINEBREAK%You may reveal and execute red maneuvers even while you are stressed."""
+            text: """%REBELONLY%%LINEBREAK%Puedes revelar y ejectuar maniobras rojas incluso aunque estés bajo tensión."""
         'Ezra Bridger':
-            text: """%REBELONLY%%LINEBREAK%When attacking, if you are stressed, you may change 1 of your %FOCUS% results to a %CRIT% result."""
+            text: """%REBELONLY%%LINEBREAK%Cuando ataques, si estás bajo tensión puedes cambiar 1 de tus resultados %FOCUS% por un resultado %CRIT%."""
         'Sabine Wren':
-            text: """%REBELONLY%%LINEBREAK%Your upgrade bar gains the %BOMB% upgrade icon.  Once per round, before a friendly bomb token is removed, choose 1 enemy ship at Range 1 of that token. That ship suffers 1 damage."""
+            text: """%REBELONLY%%LINEBREAK%Tu barra de mejoras gana el icono %BOMB%.  Una vez por ronda, antes de retirar una ficha de Bomba aliada, elige 1 nave enemiga situada a Alcance 1 de esa ficha. Esa nave sufre 1 de daño."""
         '"Chopper"':
-            text: """%REBELONLY%%LINEBREAK%You may perform actions even while you are stressed.%LINEBREAK%After you perform an action while you are stressed, suffer 1 damage."""
+            text: """%REBELONLY%%LINEBREAK%Puedes realizar acciones incluso aunque estés bajo tensión.%LINEBREAK%Después de que realices una acción mientras estás bajo tensión, sufres 1 de daño."""
         'Construction Droid':
             text: '''%HUGESHIPONLY% %LIMITED%%LINEBREAK%When you perform a recover action, you may spend 1 energy to discard 1 facedown Damage card.'''
         'Cluster Bombs':
@@ -1229,7 +1243,8 @@ exportObj.cardLoaders['Español'] = () ->
         "R5-P8":
             text: """Once per round, after defending, you may roll 1 attack die.  On a %HIT% result, the attacker suffers 1 damage.  On a %CRIT% result, you and the attacker each suffer 1 damage."""
         'Thermal Detonators':
-            text: """When you reveal your maneuver dial, you may discard this card to <strong>drop</strong> 1 thermal detonator token.%LINEBREAK%This token <strong>detonates</strong> at the end of the Activation phase.%LINEBREAK%<strong>Thermal Detonator Token:</strong> When this bomb token detonates, each ship at Range 1 of the token suffers 1 damage and receives 1 stress token.  Then discard this token."""
+            name: "Detonadores Térmicos"
+            text: """Cuando reveles tu selector de maniobras, puedes descartar esta carta para <strong>soltar</strong> 1 ficha de Detonador térmico.%LINEBREAK%Esta ficha se <strong>detona</strong> al final de la fase de Activación.%LINEBREAK%<strong>Ficha de Detonador Térmico:</strong> Cuando esta bomba detona, cada nave a Alcance 1 de la ficha sufre 1 de daño y recibe 1 ficha de tensión.  Después, descarta esta ficha."""
         "Overclocked R4":
             text: """During the Combat phase, when you spend a focus token, you may receive 1 stress token to assign 1 focus token to your ship."""
 
@@ -1389,9 +1404,11 @@ exportObj.cardLoaders['Español'] = () ->
             text: """<span class="card-restriction">Solo VT-49 Diezmador.</span><br /><br />Después de que ejecutes una maniobra que te solape con otra nave, puedes realizar 1 acción gratuita. Luego recibes 1 ficha de Tensión."""
             ship: 'VT-49 Diezmador'
         "Ghost":
-            text: """<span class="card-restriction">VCX-100 only.</span>%LINEBREAK%Equip the <em>Phantom</em> title card to a friendly Attack Shuttle and dock it to this ship.%LINEBREAK%After you execute a maneuver, you may deploy it from your rear guides."""
+            name: "Espíritu"
+            text: """<span class="card-restriction">Sólo VCX-100.</span>%LINEBREAK%Equipa la carta de Título <em>Fantasma</em> a una Lanzadera de ataque aliada y acóplala a esta nave.%LINEBREAK%Después de que ejecutes una maniobra, puedes desplegar la Lanzadera de ataque desde los salientes de la parte trasera de tu peana."""
         "Phantom":
-            text: """While you are docked, the <em>Ghost</em> can perform primary weapon attacks from its special firing arc, and, at the end of the Combat phase, it may perform an additional attack with an equipped %TURRET%. If it performs this attack, it cannot attack again this round."""
+            name: "Fantasma"
+            text: """Mientras estás acoplado, el <em>Espíritu</em> puede efectuar ataques de armamento principal desde su arco de fuego especial y, al final de la fase de Combate, puede efectuar un ataque adicional con una %TURRET% equipada. Si efectúa este ataque, no puede volver a atacar durante esta ronda."""
         "TIE/v1":
             text: """<span class="card-restriction">TIE Advanced Prototype only.</span>%LINEBREAK%After you acquire a target lock, you may perform a free evade action."""
         "Mist Hunter":
@@ -1418,6 +1435,7 @@ exportObj.cardLoaders['Español'] = () ->
             ship: 'Defensor TIE'
         'TIE Shuttle':
             text: '''<span class="card-restriction">TIE Bomber only.</span>%LINEBREAK%Your upgrade bar loses all %TORPEDO%, %MISSILE%, and %BOMB% upgrade icons and gains 2 %CREW% upgrade icons.  You cannot equip a %CREW% Upgrade card that costs more than 4 squad points.'''
+            ship: 'Bombardero TIE'
         'Requiem':
             text: '''%GOZANTIONLY%%LINEBREAK%When you deploy a ship, treat its pilot skill value as "8" until the end of the round.'''
         'Vector':

--- a/jade/index.jade
+++ b/jade/index.jade
@@ -84,7 +84,7 @@ html
 
                     German translation by [failgod](https://github.com/failgod-marcus) and [strikegun](https://github.com/strikegun) from FFG Forums.
 
-                    Spanish translation by [evil_wins Solo](http://boardgamegeek.com/user/sebaslocox) from BoardGameGeek forums and [negroscuro](https://github.com/negroscuro).
+                    Spanish translation by [evil_wins Solo](http://boardgamegeek.com/user/sebaslocox) from BoardGameGeek forums, [negroscuro](https://github.com/negroscuro) and [Kharn](https://github.com/Kharnete).
 
                     French translation by [pejuaxel](https://github.com/pejuaxel).
 


### PR DESCRIPTION
**Cards-es.coffe:**

-Translated all the cards included in the Ghost expansion pack
-Translated all the names of the Wave 8 Expansion Packs.
-Added the Lothal Rebel pilot for the VCX (and it's translation) as it was missing.
-Added two TIE Bombers pilots from the future Veteran pack that weren't showing in the builder, including the 'ship' tag to secure the deal.
-Added the 'ship: TIE Bomber' tag in the TIE Shuttle title as the title slot was missing on them.

**index.jade**

-Took the liberty of adding myself in the Spanish credits. Not that I care of these things, but it was starting to feel weird even to me :P


And I think that's all. Rest of Wave 8 once I get my hands on them. It had a late release in Spain due holidays.