### PR TITLE
Fix: Wullfwarro -> Wullffwarro

### DIFF
--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -4538,7 +4538,7 @@ exportObj.basicCardData = ->
             points: 28
         }
         {
-            name: 'Wullfwarro'
+            name: 'Wullffwarro'
             id: 252
             faction: 'Rebel Alliance'
             unique: true

--- a/coffeescripts/cards-de.coffee
+++ b/coffeescripts/cards-de.coffee
@@ -925,7 +925,7 @@ exportObj.cardLoaders.Deutsch = () ->
             text: '''After defending, if you did not roll exactly 2 defense dice, the attacker receives 1 stress token.'''
         'Lowhhrick':
             text: '''When another friendly ship at Range 1 is defending, you may spend 1 reinforce token. If you do, the defender adds 1 %EVADE% result.'''
-        'Wullfwarro':
+        'Wullffwarro':
             text: '''When attacking, if you have no shields and at least 1 Damage card assigned to you, roll 1 additional attack die.'''
 
     upgrade_translations =

--- a/coffeescripts/cards-en.coffee
+++ b/coffeescripts/cards-en.coffee
@@ -518,7 +518,7 @@ exportObj.cardLoaders.English = () ->
             text: '''After defending, if you did not roll exactly 2 defense dice, the attacker receives 1 stress token.'''
         'Lowhhrick':
             text: '''When another friendly ship at Range 1 is defending, you may spend 1 reinforce token. If you do, the defender adds 1 %EVADE% result.'''
-        'Wullfwarro':
+        'Wullffwarro':
             text: '''When attacking, if you have no shields and at least 1 Damage card assigned to you, roll 1 additional attack die.'''
 
     upgrade_translations =

--- a/coffeescripts/cards-es.coffee
+++ b/coffeescripts/cards-es.coffee
@@ -994,7 +994,7 @@ exportObj.cardLoaders['Español'] = () ->
             text: '''After defending, if you did not roll exactly 2 defense dice, the attacker receives 1 stress token.'''
         'Lowhhrick':
             text: '''When another friendly ship at Range 1 is defending, you may spend 1 reinforce token. If you do, the defender adds 1 %EVADE% result.'''
-        'Wullfwarro':
+        'Wullffwarro':
             text: '''When attacking, if you have no shields and at least 1 Damage card assigned to you, roll 1 additional attack die.'''
 
     upgrade_translations =

--- a/coffeescripts/cards-fr.coffee
+++ b/coffeescripts/cards-fr.coffee
@@ -710,7 +710,7 @@ exportObj.cardLoaders['Français'] = () ->
             text: '''After defending, if you did not roll exactly 2 defense dice, the attacker receives 1 stress token.'''
         'Lowhhrick':
             text: '''When another friendly ship at Range 1 is defending, you may spend 1 reinforce token. If you do, the defender adds 1 %EVADE% result.'''
-        'Wullfwarro':
+        'Wullffwarro':
             text: '''When attacking, if you have no shields and at least 1 Damage card assigned to you, roll 1 additional attack die.'''
 
     upgrade_translations =

--- a/coffeescripts/cards-hu.coffee
+++ b/coffeescripts/cards-hu.coffee
@@ -504,7 +504,7 @@ exportObj.cardLoaders.Magyar = () ->
             text: '''After defending, if you did not roll exactly 2 defense dice, the attacker receives 1 stress token.'''
         'Lowhhrick':
             text: '''When another friendly ship at Range 1 is defending, you may spend 1 reinforce token. If you do, the defender adds 1 %EVADE% result.'''
-        'Wullfwarro':
+        'Wullffwarro':
             text: '''When attacking, if you have no shields and at least 1 Damage card assigned to you, roll 1 additional attack die.'''
 
     upgrade_translations =

--- a/coffeescripts/cards-pl.coffee
+++ b/coffeescripts/cards-pl.coffee
@@ -676,7 +676,7 @@ exportObj.cardLoaders['Polski'] = () ->
             text: '''After defending, if you did not roll exactly 2 defense dice, the attacker receives 1 stress token.'''
         'Lowhhrick':
             text: '''When another friendly ship at Range 1 is defending, you may spend 1 reinforce token. If you do, the defender adds 1 %EVADE% result.'''
-        'Wullfwarro':
+        'Wullffwarro':
             text: '''When attacking, if you have no shields and at least 1 Damage card assigned to you, roll 1 additional attack die.'''
 
     upgrade_translations =

--- a/coffeescripts/cards-tr.coffee
+++ b/coffeescripts/cards-tr.coffee
@@ -470,7 +470,7 @@ exportObj.cardLoaders['Türkçe'] = () ->
             text: '''After defending, if you did not roll exactly 2 defense dice, the attacker receives 1 stress token.'''
         'Lowhhrick':
             text: '''When another friendly ship at Range 1 is defending, you may spend 1 reinforce token. If you do, the defender adds 1 %EVADE% result.'''
-        'Wullfwarro':
+        'Wullffwarro':
             text: '''When attacking, if you have no shields and at least 1 Damage card assigned to you, roll 1 additional attack die.'''
 
     upgrade_translations =


### PR DESCRIPTION
The pilot name has a typo.

![Wullffwarro](https://images-cdn.fantasyflightgames.com/filer_public/67/6f/676f4529-3c81-4c35-b116-90d6341d3226/swx64-wullffwarro.png)