### PR TITLE
Removes -swx70 canonical_name suffix for dalan oberos in the m12-l

### DIFF
--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -4939,7 +4939,7 @@ exportObj.basicCardData = ->
         }
         {
             name: 'Dalan Oberos (Kimogila)'
-            canonical_name: "#{'Dalan Oberos'.canonicalize()}-swx70"
+            canonical_name: "dalanoberos"
             id: 272
             unique: true
             faction: 'Scum and Villainy'


### PR DESCRIPTION
Per the XWS spec, pilots only need the release SKU suffix if they are in the same faction and ship (i.e. Han Solo, Poe Dameron, etc.)