### PR TITLE
Fixes text for crossfire formation upgrade card

### DIFF
--- a/coffeescripts/cards-en.coffee
+++ b/coffeescripts/cards-en.coffee
@@ -1264,7 +1264,7 @@ exportObj.cardLoaders.English = () ->
         'Os-1 Arsenal Loadout':
             text: '''<span class="card-restriction">Alpha-class Star Wing only.</span>%LINEBREAK%Your upgrade bar gains the %TORPEDO% and %MISSILE% icons.%LINEBREAK%You may perform attacks with %TORPEDO% and %MISSILE% secondary weapons against ships you have locked even while you have a weapons disabled token.'''
         'Crossfire Formation':
-            text: '''<span class="card-restriction">B/SF-17 Bomber only.</span>%LINEBREAK%When defending, if there is at least 1 other friendly Resistance ship at Range 1-2 of the attacker with the Crossfire Formation Upgrade card, you may add 1 %FOCUS% result to your roll.'''
+            text: '''<span class="card-restriction">B/SF-17 Bomber only.</span>%LINEBREAK%When defending, if there is at least 1 other friendly Resistance ship at Range 1-2 of the attacker, you may add 1 %FOCUS% result to your roll.'''
 
     condition_translations =
         '''I'll Show You the Dark Side''':


### PR DESCRIPTION
Image from preview article.

![crossfire formation](https://images-cdn.fantasyflightgames.com/filer_public/fb/32/fb323bf4-6067-4dff-bd41-5b1424f0c100/swx67-crossfire-formation.png)